### PR TITLE
Providing a GNFData instance for V1

### DIFF
--- a/Control/DeepSeq/Generics.hs
+++ b/Control/DeepSeq/Generics.hs
@@ -79,8 +79,8 @@ genericRnf = grnf_ . from
 class GNFData f where
     grnf_ :: f a -> ()
 
--- note: the V1 instance is not provided, as uninhabited types can't
--- be reduced to NF anyway
+instance GNFData V1 where
+  grnf_ = undefined
 
 instance GNFData U1 where
     grnf_ !U1 = ()


### PR DESCRIPTION
Although V1 is uninhabited, the lack of an instance for V1 prevents GHC from inferring an instance for types such as (U1 :+: V1), which very much is inhabited. I've encountered types like that when creating Generic instances for certain GADTs.
