### PR TITLE
Allow base 4.15 and ghc-prim 0.7

### DIFF
--- a/deepseq-generics.cabal
+++ b/deepseq-generics.cabal
@@ -44,7 +44,7 @@ source-repository head
 library
     default-language:    Haskell2010
     exposed-modules:     Control.DeepSeq.Generics
-    build-depends:       base >= 4.5 && < 4.15, ghc-prim >= 0.2 && < 0.7, deepseq >= 1.2.0.1 && < 1.5
+    build-depends:       base >= 4.5 && < 4.16, ghc-prim >= 0.2 && < 0.8, deepseq >= 1.2.0.1 && < 1.5
     other-extensions:    BangPatterns, FlexibleContexts, TypeOperators
     ghc-options:         -Wall
 


### PR DESCRIPTION
This allows building with GHC 9.0.1. Fixes #10