### PR TITLE
Bump bounds for GHC 9.4

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,18 +8,24 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.14.1
+# version: 0.15.20221009
 #
-# REGENDATA ("0.14.1",["github","deepseq-generics.cabal"])
+# REGENDATA ("0.15.20221009",["github","deepseq-generics.cabal"])
 #
 name: Haskell-CI
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - master
+      - ci*
+  pull_request:
+    branches:
+      - master
+      - ci*
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     timeout-minutes:
       60
     container:
@@ -28,6 +34,31 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.4.2
+            compilerKind: ghc
+            compilerVersion: 9.4.2
+            setup-method: ghcup
+            allow-failure: false
+          - compiler: ghc-9.4.1
+            compilerKind: ghc
+            compilerVersion: 9.4.1
+            setup-method: ghcup
+            allow-failure: false
+          - compiler: ghc-9.2.4
+            compilerKind: ghc
+            compilerVersion: 9.2.4
+            setup-method: ghcup
+            allow-failure: false
+          - compiler: ghc-9.2.3
+            compilerKind: ghc
+            compilerVersion: 9.2.3
+            setup-method: ghcup
+            allow-failure: false
+          - compiler: ghc-9.2.2
+            compilerKind: ghc
+            compilerVersion: 9.2.2
+            setup-method: ghcup
+            allow-failure: false
           - compiler: ghc-9.2.1
             compilerKind: ghc
             compilerVersion: 9.2.1
@@ -186,18 +217,18 @@ jobs:
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common libtinfo5
           if [ "${{ matrix.setup-method }}" = ghcup ]; then
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.17.3/x86_64-linux-ghcup-0.1.17.3 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER"
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
+            "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           else
             apt-add-repository -y 'ppa:hvr/ghc'
             apt-get update
             apt-get install -y "$HCNAME"
             mkdir -p "$HOME/.ghcup/bin"
-            curl -sL https://downloads.haskell.org/ghcup/0.1.17.3/x86_64-linux-ghcup-0.1.17.3 > "$HOME/.ghcup/bin/ghcup"
+            curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.6.2.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           fi
         env:
           HCKIND: ${{ matrix.compilerKind }}
@@ -340,7 +371,7 @@ jobs:
           ${CABAL} -vnormal check
       - name: haddock
         run: |
-          $CABAL v2-haddock $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
+          $CABAL v2-haddock --haddock-all $ARG_COMPILER --with-haddock $HADDOCK $ARG_TESTS $ARG_BENCH all
       - name: unconstrained build
         run: |
           rm -f cabal.project.local

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -79,54 +79,9 @@ jobs:
             compilerVersion: 8.10.7
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-8.10.6
-            compilerKind: ghc
-            compilerVersion: 8.10.6
-            setup-method: ghcup
-            allow-failure: false
-          - compiler: ghc-8.10.5
-            compilerKind: ghc
-            compilerVersion: 8.10.5
-            setup-method: ghcup
-            allow-failure: false
-          - compiler: ghc-8.10.4
-            compilerKind: ghc
-            compilerVersion: 8.10.4
-            setup-method: hvr-ppa
-            allow-failure: false
-          - compiler: ghc-8.10.3
-            compilerKind: ghc
-            compilerVersion: 8.10.3
-            setup-method: hvr-ppa
-            allow-failure: false
-          - compiler: ghc-8.10.2
-            compilerKind: ghc
-            compilerVersion: 8.10.2
-            setup-method: hvr-ppa
-            allow-failure: false
-          - compiler: ghc-8.10.1
-            compilerKind: ghc
-            compilerVersion: 8.10.1
-            setup-method: hvr-ppa
-            allow-failure: false
           - compiler: ghc-8.8.4
             compilerKind: ghc
             compilerVersion: 8.8.4
-            setup-method: hvr-ppa
-            allow-failure: false
-          - compiler: ghc-8.8.3
-            compilerKind: ghc
-            compilerVersion: 8.8.3
-            setup-method: hvr-ppa
-            allow-failure: false
-          - compiler: ghc-8.8.2
-            compilerKind: ghc
-            compilerVersion: 8.8.2
-            setup-method: hvr-ppa
-            allow-failure: false
-          - compiler: ghc-8.8.1
-            compilerKind: ghc
-            compilerVersion: 8.8.1
             setup-method: hvr-ppa
             allow-failure: false
           - compiler: ghc-8.6.5
@@ -134,44 +89,9 @@ jobs:
             compilerVersion: 8.6.5
             setup-method: hvr-ppa
             allow-failure: false
-          - compiler: ghc-8.6.4
-            compilerKind: ghc
-            compilerVersion: 8.6.4
-            setup-method: hvr-ppa
-            allow-failure: false
-          - compiler: ghc-8.6.3
-            compilerKind: ghc
-            compilerVersion: 8.6.3
-            setup-method: hvr-ppa
-            allow-failure: false
-          - compiler: ghc-8.6.2
-            compilerKind: ghc
-            compilerVersion: 8.6.2
-            setup-method: hvr-ppa
-            allow-failure: false
-          - compiler: ghc-8.6.1
-            compilerKind: ghc
-            compilerVersion: 8.6.1
-            setup-method: hvr-ppa
-            allow-failure: false
           - compiler: ghc-8.4.4
             compilerKind: ghc
             compilerVersion: 8.4.4
-            setup-method: hvr-ppa
-            allow-failure: false
-          - compiler: ghc-8.4.3
-            compilerKind: ghc
-            compilerVersion: 8.4.3
-            setup-method: hvr-ppa
-            allow-failure: false
-          - compiler: ghc-8.4.2
-            compilerKind: ghc
-            compilerVersion: 8.4.2
-            setup-method: hvr-ppa
-            allow-failure: false
-          - compiler: ghc-8.4.1
-            compilerKind: ghc
-            compilerVersion: 8.4.1
             setup-method: hvr-ppa
             allow-failure: false
           - compiler: ghc-8.2.2
@@ -202,11 +122,6 @@ jobs:
           - compiler: ghc-7.4.2
             compilerKind: ghc
             compilerVersion: 7.4.2
-            setup-method: hvr-ppa
-            allow-failure: false
-          - compiler: ghc-7.4.1
-            compilerKind: ghc
-            compilerVersion: 7.4.1
             setup-method: hvr-ppa
             allow-failure: false
       fail-fast: false

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-dist/
+/dist/
+/dist-newstyle/
 *~

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -1,0 +1,1 @@
+branches: master ci*

--- a/deepseq-generics.cabal
+++ b/deepseq-generics.cabal
@@ -1,14 +1,14 @@
 name:                deepseq-generics
 version:             0.2.0.0
-x-revision: 7
+x-revision: 8
 
 synopsis:            GHC.Generics-based Control.DeepSeq.rnf implementation
-homepage:            https://github.com/hvr/deepseq-generics
-bug-reports:         https://github.com/hvr/deepseq-generics/issues
+homepage:            https://github.com/haskell-hvr/deepseq-generics
+bug-reports:         https://github.com/haskell-hvr/deepseq-generics/issues
 license:             BSD3
 license-file:        LICENSE
 author:              Herbert Valerio Riedel
-maintainer:          hvr@gnu.org
+maintainer:          https://github.com/haskell-hvr
 copyright:           2012, Herbert Valerio Riedel
 category:            Control
 build-type:          Simple
@@ -18,16 +18,16 @@ tested-with:
   GHC == 9.4.*
   GHC == 9.2.*
   GHC == 9.0.*
-  GHC == 8.10.*
-  GHC == 8.8.*
-  GHC == 8.6.*
-  GHC == 8.4.*
+  GHC == 8.10.7
+  GHC == 8.8.4
+  GHC == 8.6.5
+  GHC == 8.4.4
   GHC == 8.2.2
   GHC == 8.0.2
   GHC == 7.10.3
   GHC == 7.8.4
   GHC == 7.6.3
-  GHC == 7.4.*
+  GHC == 7.4.2
 
 description:
     This package provides a "GHC.Generics"-based
@@ -54,7 +54,7 @@ extra-source-files: changelog.md
 
 source-repository head
     type:     git
-    location: https://github.com/hvr/deepseq-generics.git
+    location: https://github.com/haskell-hvr/deepseq-generics.git
 
 library
     default-language:    Haskell2010
@@ -74,11 +74,11 @@ test-suite deepseq-generics-tests
     ghc-options:         -Wall
 
     build-depends:
-        base,
-        deepseq,
-        deepseq-generics,
-        ghc-prim,
+        base
+      , deepseq
+      , deepseq-generics
+      , ghc-prim
         -- end of packages with inherited version constraints
-        test-framework >= 0.6.1 && < 0.9,
-        test-framework-hunit >= 0.2.2 && < 0.9,
-        HUnit >= 1.2.5 && < 1.7
+      , test-framework       >= 0.6.1 && < 0.9
+      , test-framework-hunit >= 0.2.2 && < 0.9
+      , HUnit                >= 1.2.5 && < 1.7

--- a/deepseq-generics.cabal
+++ b/deepseq-generics.cabal
@@ -15,6 +15,7 @@ build-type:          Simple
 cabal-version:       >=1.10
 
 tested-with:
+  GHC == 9.4.*
   GHC == 9.2.*
   GHC == 9.0.*
   GHC == 8.10.*
@@ -58,8 +59,8 @@ source-repository head
 library
     default-language:    Haskell2010
     exposed-modules:     Control.DeepSeq.Generics
-    build-depends:       base     >= 4.5     && < 4.17
-                       , ghc-prim >= 0.2     && < 0.9
+    build-depends:       base     >= 4.5     && < 4.18
+                       , ghc-prim >= 0.2     && < 0.10
                        , deepseq  >= 1.2.0.1 && < 1.5
     other-extensions:    BangPatterns, FlexibleContexts, TypeOperators
     ghc-options:         -Wall


### PR DESCRIPTION
Pushed as revision 8 to hackage: https://hackage.haskell.org/package/deepseq-generics-0.2.0.0/revisions/